### PR TITLE
動画数を500を超えると動画一覧を正しく取得できない問題を修正

### DIFF
--- a/channel_video_list/main.py
+++ b/channel_video_list/main.py
@@ -153,7 +153,7 @@ def get_new_videos(videos, completed_videos):
 
 def main(request):
     name = parse_request(request, 'name')
-    full_retry = parse_request(request, 'full_refresh')
+    full_retry = parse_request(request, 'full_retry')
     channels = gcs_wrapper.get_gcs_file_to_dictlist(bucket_name, 'channels.json')
 
     channel_id = channel_name_to_id(name)
@@ -176,6 +176,7 @@ def main(request):
 
     completed_videoinfos.extend(new_videoinfos)
 
+    file_path = 'videos_v2/videolist' + channel_id + '.json'
     gcs_wrapper.upload_gcs_file_from_dictlist(bucket_name, file_path,completed_videoinfos)
     print("Success to get and upload videos of " + escape(name))
 
@@ -186,7 +187,7 @@ if __name__ == '__main__':
     videos = get_videos(channel_id)
     completed_videoinfos = get_completed_videos(channel_id)
     comp_videos = []
-    if full_refresh == "yes":
+    if full_retry == "yes":
         print("Re-scan all videos " + name + " " + channel_id)
         completed_videoinfos = []
     for videoinfo in completed_videoinfos:

--- a/channel_video_list/main.py
+++ b/channel_video_list/main.py
@@ -5,6 +5,8 @@ import platform
 import json
 import sys
 import os
+import numpy
+import math
 from unittest.mock import Mock
 from oauth2client.client import GoogleCredentials
 from httplib2 import Http
@@ -28,62 +30,89 @@ def get_youtube_client():
         client = build('youtube', 'v3', developerKey=api_key)
     return(client)
 
-def get_videos(channel_id, border_time):
+def get_videos(channel_id):
+    # 動画ID一覧を取得
+    # 動画数が500を超えるとvideos.listでは取得できない
+    # quota消費が多いので注意
     if channel_id is None:
         print("Must specify channel_id")
         return(None)
 
     youtube = get_youtube_client()
 
+    # channels.listからupload_idを取得
+
+    channels_response = youtube.channels().list(
+            id = channel_id,
+            part = 'contentDetails',
+            fields = 'items(contentDetails(relatedPlaylists(uploads)))',
+            maxResults = 1
+            ).execute()
+
+    uploads_id = channels_response['items'][0]['contentDetails']['relatedPlaylists']['uploads']
+
+    print(channel_id + " upload id = " + uploads_id)
+
+    # playlistsitems.listからvideo_idを取得
+
     nextPagetoken = None
     nextpagetoken = None
     videos = []
-    border = False
-    # 動画Idの取得
     while True:
         if nextPagetoken != None:
             nextpagetoken = nextPagetoken
 
-        search_response = youtube.search().list(
-          part = 'id',
-          channelId = channel_id,
-          eventType = 'completed',
-          type = 'video',
-          maxResults = 50,
-          order = 'date',
-          pageToken = nextpagetoken
-          ).execute()
-
-        for search_result in search_response.get('items', []):
-            if search_result['id']['kind'] == 'youtube#video':
-                videoinfo = {}
-                videoinfo['video_id'] = search_result['id']['videoId']
-                videos_response = youtube.videos().list(
-                        part = 'snippet, contentDetails',
-                        id = videoinfo['video_id']
-                        ).execute()
-                for video_result in videos_response.get('items', []):
-                    videoinfo['channel_id'] = video_result['snippet']['channelId']
-                    videoinfo['published_at'] = video_result['snippet']['publishedAt']
-                    videoinfo['title'] = video_result['snippet']['title']
-                    videoinfo['duration'] = video_result['contentDetails']['duration']
-
-                if border_time >= datetime.strptime(videoinfo['published_at'], '%Y-%m-%dT%H:%M:%SZ'):
-                    border = True
-                    break
-
-                videos.append(videoinfo)
-
-        if border:
-            break
+        playlist_response = youtube.playlistItems().list(
+                playlistId = uploads_id,
+                part = 'snippet',
+                fields = 'nextPageToken, items(snippet(resourceId))',
+                maxResults = 50,
+                pageToken = nextpagetoken
+                ).execute()
+        for playlist_result in playlist_response.get('items', []):
+            if playlist_result['snippet']['resourceId']['kind'] == 'youtube#video':
+                videos.append(playlist_result['snippet']['resourceId']['videoId'])
 
         try:
-            nextPagetoken =  search_response["nextPageToken"]
+            nextPagetoken =  playlist_response["nextPageToken"]
         except:
             break
 
+    print(channel_id + " contains " + ("%03d" % len(videos)) + " videos")
     return(videos)
 
+def get_videoinfos(videos):
+    # viode_idのlistを受け取り詳細を取得する
+
+    if len(videos) == 0:
+        return([])
+    if len(videos) < 50:
+        iterate_num = 1
+    else:
+        iterate_num = math.floor(len(videos) / 50) + 1
+
+    youtube = get_youtube_client()
+    video_infos = []
+    video_lists = []
+    for video_array in numpy.array_split(videos, iterate_num):
+        video_lists.append(video_array.tolist())
+
+    for video_list in video_lists:
+        video_ids = ",".join(video_list)
+        videos_response = youtube.videos().list(
+                part = 'snippet, contentDetails',
+                id = video_ids
+                ).execute()
+        for video_result in videos_response.get('items', []):
+            videoinfo = {}
+            videoinfo['video_id'] = video_result['id']
+            videoinfo['channel_id'] = video_result['snippet']['channelId']
+            videoinfo['published_at'] = video_result['snippet']['publishedAt']
+            videoinfo['title'] = video_result['snippet']['title']
+            videoinfo['duration'] = video_result['contentDetails']['duration']
+            video_infos.append(videoinfo)
+
+    return(video_infos)
 
 def parse_request(request, key):
     request_json = request.get_json(silent=True)
@@ -96,42 +125,75 @@ def parse_request(request, key):
 
     return(value)
 
-
-def main(request):
-    name = parse_request(request, 'name')
-    full_retry = parse_request(request, 'full_retry')
-    max_published_at = datetime.strptime('2000-01-01T00:00:00Z', '%Y-%m-%dT%H:%M:%SZ')
+def channel_name_to_id(name):
+    # 名称をchannel_idに変換させる
+    channel_id = None
     channels = gcs_wrapper.get_gcs_file_to_dictlist(bucket_name, 'channels.json')
-
     for channel in channels:
         if channel['name'] == name:
             channel_id = channel['channel_id']
             print(channel)
 
+    return(channel_id)
+
+def get_completed_videos(channel_id):
+    # GCSに保存した動画一覧を読み出す
+    completed_videoinfos = []
+    file_path = 'videos_v2/videolist' + channel_id + '.json'
+    if gcs_wrapper.check_gcs_file_exists(bucket_name, file_path):
+        completed_videoinfos = gcs_wrapper.get_gcs_file_to_dictlist(bucket_name, file_path)
+    return(completed_videoinfos)
+
+def get_new_videos(videos, completed_videos):
+    # 取得済の動画と動画一覧を比較して差分を返す
+
+    diff_videos = list(set(videos) - set(completed_videos))
+    print("new videos = " + ("%03d" % len(diff_videos)))
+    return(diff_videos)
+
+def main(request):
+    name = parse_request(request, 'name')
+    full_retry = parse_request(request, 'full_refresh')
+    channels = gcs_wrapper.get_gcs_file_to_dictlist(bucket_name, 'channels.json')
+
+    channel_id = channel_name_to_id(name)
+
     if not channel_id:
         return
-    file_path = 'videos_v2/videolist' + channel_id + '.json'
 
-    if full_retry:
-        videos = get_videos(channel_id, max_published_at)
-    else:
-        if gcs_wrapper.check_gcs_file_exists(bucket_name, file_path):
-            videos = gcs_wrapper.get_gcs_file_to_dictlist(bucket_name, file_path)
-            for videoinfo in videolist:
-                if max_published_at < datetime.strptime(videoinfo['published_at'], '%Y-%m-%dT%H:%M:%SZ'):
-                    max_published_at = datetime.strptime(videoinfo['published_at'], '%Y-%m-%dT%H:%M:%SZ')
-        else:
-            videos = []
-        new_videos = get_videos(channel_id, max_published_at)
-        videos.extend(new_videos)
+    videos = get_videos(channel_id)
+    completed_videoinfos = get_completed_videos(channel_id)
 
-    gcs_wrapper.upload_gcs_file_from_dictlist(bucket_name, file_path,videos)
+    if full_retry == "yes":
+        print("Re-scan all videos " + name + " " + channel_id)
+        completed_videoinfos = []
+
+    comp_videos = []
+    for videoinfo in completed_videoinfos:
+        comp_videos.append(videoinfo['video_id'])
+    new_videos = get_new_videos(videos, comp_videos)
+    new_videoinfos = get_videoinfos(new_videos)
+
+    completed_videoinfos.extend(new_videoinfos)
+
+    gcs_wrapper.upload_gcs_file_from_dictlist(bucket_name, file_path,completed_videoinfos)
     print("Success to get and upload videos of " + escape(name))
 
 if __name__ == '__main__':
     name = sys.argv[1]
     full_retry = sys.argv[2]
-    data = {'name': name, 'full_retry': full_retry}
-    req = Mock(get_json=Mock(return_value=data), args=data)
-    main(req)
+    channel_id = channel_name_to_id(name)
+    videos = get_videos(channel_id)
+    completed_videoinfos = get_completed_videos(channel_id)
+    comp_videos = []
+    if full_refresh == "yes":
+        print("Re-scan all videos " + name + " " + channel_id)
+        completed_videoinfos = []
+    for videoinfo in completed_videoinfos:
+        comp_videos.append(videoinfo['video_id'])
+    new_videos = get_new_videos(videos, comp_videos)
+    new_videoinfos = get_videoinfos(new_videos)
+    completed_videoinfos.extend(new_videoinfos)
+    print(len(completed_videoinfos))
+
 

--- a/channel_video_list/requirements.txt
+++ b/channel_video_list/requirements.txt
@@ -3,3 +3,4 @@ google-cloud-storage==1.29.0
 Flask==1.0.2
 google-api-python-client==1.9.3
 oauth2client==4.1.3
+numpy==1.19.3


### PR DESCRIPTION
* search.listを使わずplaylistitems.listを使う方向で変更
* quota消費を劇的に改善した。というかsearch.listのコスパが悪すぎた

参考URL
https://stackoverflow.com/questions/64709715/youtube-data-api-v3-maximum-search-result-for-channel-id