### PR TITLE
Issue6 emoji check

### DIFF
--- a/continuation_livechat_crawler/locally_run.py
+++ b/continuation_livechat_crawler/locally_run.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
         dmplist.append(json.dumps(line, ensure_ascii=False))
 
     output_file = './chatlog_replay_' + video_id + '.json'
-    with open(output_file, mode='w') as f:
+    with open(output_file, mode='w', encoding='utf-8') as f:
         f.write('\n'.join(dmplist))
 
     print('DONE!')

--- a/continuation_livechat_crawler/main.py
+++ b/continuation_livechat_crawler/main.py
@@ -74,7 +74,11 @@ def convert_chatreplay(renderer):
                 if 'text' in runs:
                     content += runs['text']
                 if 'emoji' in runs:
-                    content += runs['emoji']['shortcuts'][0]
+                    is_custom_emoji = runs['emoji'].get('isCustomEmoji')
+                    if is_custom_emoji:
+                        content += ''.join(runs['emoji']['shortcuts'])
+                    else:
+                        content += runs['emoji']['emojiId']
     chatlog['text'] = content
 
     if 'purchaseAmountText' in renderer:


### PR DESCRIPTION
# issue

#6

* チャットコメントにemojiが含まれる際、通常のunicode絵文字（💩🐓🔪など）と、Youtubeチャンネルに設定されたカスタム絵文字の場合とでチャットコメントの構造体が変わっていたので修正した。isCustomEmojiというフラグで分岐させるようにした。
* #7 で言及されたWindows環境化でのErrorに対応（by @hirooo1997)
